### PR TITLE
fixed issue where changes in startRecording interface breaks code

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ var recOptions = {
 function startRecordingChunks (stream, duration, cb) {
     var rrtc = RecordRTC(stream, recOptions)
     // start it recording
-    rrtc.startRecording()
-        .setRecordingDuration(duration)
+    rrtc.setRecordingDuration(duration)
         // when it stops,
         .onRecordingStopped(videoURL => {
             // call cb on the video blob
@@ -30,6 +29,8 @@ function startRecordingChunks (stream, duration, cb) {
             // start recording again
             startRecordingChunks(stream, duration, cb)
         })
+    // using pattern from https://www.webrtc-experiment.com/RecordRTC/simple-demos/setRecordingDuration.html
+    rrtc.startRecording()
 }
 
 


### PR DESCRIPTION
There seems to be an issue with the current version of the repo where the manner in which onrecordingstopped is called does not register the appropriate callback.

This fix follows the RecordRTC usage shown at this link:
https://www.webrtc-experiment.com/RecordRTC/simple-demos/setRecordingDuration.html

Tested on my local machine, it works.

